### PR TITLE
Remove unnecessary localhost hack

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -54,9 +54,7 @@ const spotify = namespace('spotify');
         body: qs.stringify({
           grant_type: 'authorization_code',
           code: query.code,
-          redirect_uri: location.host.includes('localhost')
-            ? 'http://localhost'
-            : `${location.protocol}//${location.host}`,
+          redirect_uri: `${location.protocol}//${location.host}`,
         }),
       }).then((res) => res.json())) as any);
 


### PR DESCRIPTION
We don't need that localhost hack, since Spotify now allows the localhost:3000 as a valid callback URL when you add it to the dashboard.

Thanks to @pmareke 